### PR TITLE
Add paperless_secret_key as variable & don't require email user/password

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ paperless_tmp_size: 10000
 paperless_hostname: ''
 paperless_url: 'https://{{ paperless_hostname }}'
 paperless_app_title: 'Paperless-ngx'
+paperless_secret_key: ''
 
 paperless_uid: ''
 paperless_gid: ''

--- a/tasks/validate_config.yml
+++ b/tasks/validate_config.yml
@@ -18,6 +18,4 @@
       You need to define a required configuration setting (`{{ item }}`) to correctly set up email via SMTP.
   when: "paperless_email_host !='' and vars[item] == ''"
   with_items:
-    - paperless_email_username
-    - paperless_email_password
     - paperless_email_port

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -15,6 +15,10 @@ PAPERLESS_ADMIN_USER={{ paperless_admin_user }}
 PAPERLESS_ADMIN_PASSWORD={{ paperless_admin_password }}
 {% endif %}
 
+{% if paperless_secret_key %}
+PAPERLESS_SECRET_KEY={{ paperless_secret_key }}
+{% endif %}
+
 
 
 {% if paperless_email_host %}


### PR DESCRIPTION
Thank you for creating this ansible role!

This PR adds the [PAPERLESS_SECRET_KEY](https://docs.paperless-ngx.com/configuration/#PAPERLESS_SECRET_KEY) and removes the requirement for the email username and password, to also support sending mails without authentication.
This is nesessary to support the [exim-relay](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/services/exim-relay.md) in the MASH-playbook.