### PR TITLE
add the ability to use a subpath instead of subdomain

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,6 +34,9 @@ paperless_container_consume_path: "/usr/src/paperless/consume"
 
 paperless_env_path: "{{ paperless_base_path }}/env"
 
+#Do NOT include a trailing slash. e.g. /paperless - Not implemented into traefik
+paperless_subpath: ''
+
 paperless_database_hostname: ''
 paperless_database_port: 5432
 paperless_database_name: paperless

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -14,6 +14,10 @@ PAPERLESS_APP_TITLE={{ paperless_app_title }}
 PAPERLESS_ADMIN_USER={{ paperless_admin_user }}
 PAPERLESS_ADMIN_PASSWORD={{ paperless_admin_password }}
 {% endif %}
+{% if paperless_subpath %}
+PAPERLESS_STATIC_URL={{ paperless_subpath}}/static/
+PAPERLESS_FORCE_SCRIPT_NAME={{ paperless_subpath }}
+{% endif %}
 
 {% if paperless_secret_key %}
 PAPERLESS_SECRET_KEY={{ paperless_secret_key }}


### PR DESCRIPTION
I don't know if something has to be changed for traefik, i am running this with this vars.yml

```
paperless_hostname: examle.com
paperless_subpath: /paperless
```
and this nginx config:
```
	location /paperless {
		proxy_pass http://127.0.0.1:8731;
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";

        proxy_redirect off;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Host $server_name;
        add_header Referrer-Policy "strict-origin-when-cross-origin";
	}
```