### PR TITLE
change the uid/gid in the container to the corresponding mash user

### DIFF
--- a/templates/env.j2
+++ b/templates/env.j2
@@ -1,3 +1,5 @@
+USERMAP_UID={{ mash_playbook_uid }}
+USERMAP_GID={{ mash_playbook_gid }}
 PAPERLESS_PORT={{ paperless_container_http_port }}
 PAPERLESS_REDIS={{ paperless_redis_url }}
 

--- a/templates/systemd/paperless.service.j2
+++ b/templates/systemd/paperless.service.j2
@@ -15,7 +15,6 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--rm \
 			--name={{ paperless_identifier }} \
 			--log-driver=none \
-			--read-only \
 			--network={{ paperless_container_network }} \
 			{% if paperless_container_http_host_bind_port %}
 			-p {{ paperless_container_http_host_bind_port }}:{{ paperless_container_http_port }} \


### PR DESCRIPTION
In my opinion If you don't change the uid/gid you have a potential security problem depending on the use of the server.
Because on the host system the owner will be that one with the id 1000 and the group will that one with the id 1000.

The  disadvantage is that you have to make / in the container rw...