### PR TITLE
feat: add support for paperless-tika and gotenburg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 19.05.2024
+- Added support for gotenberg and tika
+  configure it by setting `paperless_tika_enabled` and `paperless_gotenberg_enabled` to `true`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-# Project source code URL: https://github.com/gopaperless/paperless
+# Project source code URL: https://github.com/paperless-ngx/paperless-ngx
 
 paperless_enabled: true
 paperless_identifier: paperless

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -63,6 +63,7 @@ paperless_email_username: ''
 paperless_email_password: ''
 paperless_email_from: "noreply@{{ paperless_hostname }}"
 
+
 # Additional environment variables to pass to the paperless container.
 # You can use this to further influence the default configuration.
 # Check https://gopaperless.io/docs/installation/configuration for a full configuration reference
@@ -219,6 +220,33 @@ paperless_hsts_preload_enabled: false
 paperless_container_labels_additional_labels: ''
 
 paperless_variables_additional_variables: ''
+
+
+########################
+## tika and gotenberg ##
+########################
+
+# Project source code URL: https://github.com/apache/tika
+paperless_tika_enabled: false
+paperless_tika_identifier: "{{ paperless_identifier }}-tika"
+paperless_tika_endpoint: "http://{{ paperless_tika_identifier }}:9998"
+paperless_tika_container_additional_mounts: []
+paperless_tika_container_registry_prefix: "ghcr.io/"
+paperless_tika_version: "2.9.1-minimal"
+paperless_tika_container_image: "{{ paperless_tika_container_registry_prefix }}paperless-ngx/tika:{{ paperless_tika_version }}"
+paperless_tika_environment_variables_extension: ''
+paperless_tika_container_labels_additional_labels: ''
+
+# Project source code URL: https://github.com/gotenberg/gotenberg
+paperless_gotenberg_enabled: false
+paperless_gotenberg_identifier: "{{ paperless_identifier }}-gotenberg"
+paperless_gotenberg_endpoint: "http://{{ paperless_gotenberg_identifier }}:3000"
+paperless_gotenberg_container_additional_mounts: []
+paperless_gotenberg_container_registry_prefix: "docker.io/"
+paperless_gotenberg_version: "8.5.0"
+paperless_gotenberg_container_image: "{{ paperless_gotenberg_container_registry_prefix }}gotenberg/gotenberg:{{ paperless_gotenberg_version }}"
+paperless_gotenberg_environment_variables_extension: ''
+paperless_gotenberg_container_labels_additional_labels: ''
 
 
 ################

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -29,6 +29,8 @@
     mode: 0640
   with_items:
     - {src: "{{ role_path }}/templates/labels.j2", dest: "{{ paperless_base_path }}/labels"}
+    - {src: "{{ role_path }}/templates/tika-labels.j2", dest: "{{ paperless_base_path }}/tika-labels", when: paperless_tika_enabled}
+    - {src: "{{ role_path }}/templates/gotenberg-labels.j2", dest: "{{ paperless_base_path }}/gotenberg-labels", when: paperless_gotenberg_enabled}
 
 - name: Ensure paperless configuration is deployed
   ansible.builtin.template:
@@ -39,6 +41,8 @@
     mode: 0640
   with_items:
     - {src: "{{ role_path }}/templates/env.j2", dest: "{{ paperless_base_path }}/env"}
+    - {src: "{{ role_path }}/templates/tika-env.j2", dest: "{{ paperless_base_path }}/tika-env", when: paperless_tika_enabled}
+    - {src: "{{ role_path }}/templates/gotenberg-env.j2", dest: "{{ paperless_base_path }}/gotenberg-env", when: paperless_gotenberg_enabled}
 
 - name: Ensure paperless container image is pulled
   community.docker.docker_image:
@@ -46,6 +50,8 @@
     source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
   with_items:
     - {image: "{{ paperless_container_image }}"}
+    - {image: "{{ paperless_tika_container_image }}", when: paperless_tika_enabled}
+    - {image: "{{ paperless_gotenberg_container_image }}", when: paperless_gotenberg_enabled}
 
 - name: Ensure paperless.service installed
   ansible.builtin.template:
@@ -54,3 +60,5 @@
     mode: 0644
   with_items:
     - {src: "{{ role_path }}/templates/systemd/paperless.service.j2", dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ paperless_identifier }}.service"}
+    - {src: "{{ role_path }}/templates/systemd/paperless-tika.service.j2", dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ paperless_tika_identifier }}.service", when: paperless_tika_enabled}
+    - {src: "{{ role_path }}/templates/systemd/paperless-gotenberg.service.j2", dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ paperless_gotenberg_identifier }}.service", when: paperless_gotenberg_enabled}

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -4,6 +4,8 @@
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/remove_service.yml"
   with_items:
     - {service: "{{ paperless_identifier }}.service", path: "{{ devture_systemd_docker_base_systemd_path }}/{{ paperless_identifier }}.service"}
+    - {service: "{{ paperless_tika_identifier }}.service", path: "{{ devture_systemd_docker_base_systemd_path }}/{{ paperless_tika_identifier }}.service"}
+    - {service: "{{ paperless_gotenberg_identifier }}.service", path: "{{ devture_systemd_docker_base_systemd_path }}/{{ paperless_gotenberg_identifier }}.service"}
 
 - name: Ensure paperless base path is files deleted
   ansible.builtin.file:

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -35,4 +35,13 @@ PAPERLESS_EMAIL_USE_SSL={{ paperless_email_use_ssl }}
 PAPERLESS_EMAIL_FROM={{ paperless_email_from }}
 {% endif %}
 
+{% if paperless_tika_enabled %}
+PAPERLESS_TIKA_ENABLED={{ paperless_tika_enabled }}
+PAPERLESS_TIKA_ENDPOINT={{ paperless_tika_endpoint }}
+{% endif %}
+
+{% if paperless_gotenberg_enabled %}
+PAPERLESS_TIKA_GOTENBERG_ENDPOINT={{ paperless_gotenberg_endpoint }}
+{% endif %}
+
 {{ paperless_environment_variables_extension }}

--- a/templates/gotenberg-env.j2
+++ b/templates/gotenberg-env.j2
@@ -1,0 +1,1 @@
+{{ paperless_gotenberg_environment_variables_extension }}

--- a/templates/gotenberg-labels.j2
+++ b/templates/gotenberg-labels.j2
@@ -1,0 +1,1 @@
+{{ paperless_gotenberg_container_labels_additional_labels }}

--- a/templates/systemd/paperless-gotenberg.service.j2
+++ b/templates/systemd/paperless-gotenberg.service.j2
@@ -1,0 +1,40 @@
+[Unit]
+Description=gotenberg Server for Paperless-ngx Server ({{ paperless_identifier }})
+{% for service in paperless_systemd_required_services_list %}
+Requires={{ service }}
+After={{ service }}
+{% endfor %}
+DefaultDependencies=no
+
+[Service]
+Type=simple
+ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop --time={{ devture_systemd_docker_base_container_stop_grace_time_seconds }} {{ paperless_gotenberg_identifier }} 2>/dev/null || true'
+ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm {{ paperless_gotenberg_identifier }} 2>/dev/null || true'
+
+ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
+			--rm \
+			--name={{ paperless_gotenberg_identifier }} \
+			--log-driver=none \
+			--read-only \
+			--network={{ paperless_container_network }} \
+			--env-file={{ paperless_base_path }}/gotenberg-env \
+			--label-file={{ paperless_base_path }}/gotenberg-labels \
+			--health-interval={{ paperless_container_health_interval }} \
+			{% for mount in paperless_gotenberg_container_additional_mounts %}
+			--mount {{ mount }} \
+			{% endfor %}
+			--tmpfs=/tmp:rw,noexec,nosuid,size={{ paperless_tmp_size }}m \
+			{{ paperless_gotenberg_container_image }}
+			gotenberg --chromium-disable-javascript=true --chromium-allow-list=file:///tmp/.*
+
+
+ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach {{ paperless_gotenberg_identifier }}
+
+ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop --time={{ devture_systemd_docker_base_container_stop_grace_time_seconds }} {{ paperless_gotenberg_identifier }} 2>/dev/null || true'
+ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm {{ paperless_gotenberg_identifier }} 2>/dev/null || true'
+Restart=always
+RestartSec=30
+SyslogIdentifier={{ paperless_gotenberg_identifier }}
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/systemd/paperless-tika.service.j2
+++ b/templates/systemd/paperless-tika.service.j2
@@ -1,0 +1,39 @@
+[Unit]
+Description=tika Server for Paperless-ngx Server ({{ paperless_identifier }})
+{% for service in paperless_systemd_required_services_list %}
+Requires={{ service }}
+After={{ service }}
+{% endfor %}
+DefaultDependencies=no
+
+[Service]
+Type=simple
+ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop --time={{ devture_systemd_docker_base_container_stop_grace_time_seconds }} {{ paperless_tika_identifier }} 2>/dev/null || true'
+ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm {{ paperless_tika_identifier }} 2>/dev/null || true'
+
+ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
+			--rm \
+			--name={{ paperless_tika_identifier }} \
+			--log-driver=none \
+			--read-only \
+			--network={{ paperless_container_network }} \
+			--env-file={{ paperless_base_path }}/tika-env \
+			--label-file={{ paperless_base_path }}/tika-labels \
+			--health-interval={{ paperless_container_health_interval }} \
+			{% for mount in paperless_tika_container_additional_mounts %}
+			--mount {{ mount }} \
+			{% endfor %}
+			--tmpfs=/tmp:rw,noexec,nosuid,size={{ paperless_tmp_size }}m \
+			{{ paperless_tika_container_image }}
+
+
+ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach {{ paperless_tika_identifier }}
+
+ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop --time={{ devture_systemd_docker_base_container_stop_grace_time_seconds }} {{ paperless_tika_identifier }} 2>/dev/null || true'
+ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm {{ paperless_tika_identifier }} 2>/dev/null || true'
+Restart=always
+RestartSec=30
+SyslogIdentifier={{ paperless_tika_identifier }}
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/tika-env.j2
+++ b/templates/tika-env.j2
@@ -1,0 +1,1 @@
+{{ paperless_tika_environment_variables_extension }}

--- a/templates/tika-labels.j2
+++ b/templates/tika-labels.j2
@@ -1,0 +1,1 @@
+{{ paperless_tika_container_labels_additional_labels }}


### PR DESCRIPTION
With these two additional docker container paperless can read .eml, .dox and many more filetypes. I followed the [official paperless-ngx documentation](https://docs.paperless-ngx.com/configuration/#optional-services) and [docker example](https://github.com/paperless-ngx/paperless-ngx/blob/dev/docker/compose/docker-compose.sqlite-tika.yml).

It would be great, if you could merge this PR and set a new tag. This way I can set my [PR](https://github.com/mother-of-all-self-hosting/mash-playbook/pull/208), which is necessary to use tika, for the mash playbook to this role version. Maybe together with the new paperless Version: https://github.com/mother-of-all-self-hosting/ansible-role-paperless/pull/6