### PR TITLE
Update paperless (+ tika | + gotenberg) to latest version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@
 paperless_enabled: true
 paperless_identifier: paperless
 
-paperless_version: "2.8.6"
+paperless_version: "2.11.0"
 # In mb, default is 10gb
 paperless_tmp_size: 10000
 
@@ -231,9 +231,9 @@ paperless_tika_enabled: false
 paperless_tika_identifier: "{{ paperless_identifier }}-tika"
 paperless_tika_endpoint: "http://{{ paperless_tika_identifier }}:9998"
 paperless_tika_container_additional_mounts: []
-paperless_tika_container_registry_prefix: "ghcr.io/"
-paperless_tika_version: "2.9.1-minimal"
-paperless_tika_container_image: "{{ paperless_tika_container_registry_prefix }}paperless-ngx/tika:{{ paperless_tika_version }}"
+paperless_tika_container_registry_prefix: "docker.io/"
+paperless_tika_version: "2.9.2.1"
+paperless_tika_container_image: "{{ paperless_tika_container_registry_prefix }}apache/tika:{{ paperless_tika_version }}"
 paperless_tika_environment_variables_extension: ''
 paperless_tika_container_labels_additional_labels: ''
 
@@ -243,7 +243,7 @@ paperless_gotenberg_identifier: "{{ paperless_identifier }}-gotenberg"
 paperless_gotenberg_endpoint: "http://{{ paperless_gotenberg_identifier }}:3000"
 paperless_gotenberg_container_additional_mounts: []
 paperless_gotenberg_container_registry_prefix: "docker.io/"
-paperless_gotenberg_version: "8.5.0"
+paperless_gotenberg_version: "8.8.0"
 paperless_gotenberg_container_image: "{{ paperless_gotenberg_container_registry_prefix }}gotenberg/gotenberg:{{ paperless_gotenberg_version }}"
 paperless_gotenberg_environment_variables_extension: ''
 paperless_gotenberg_container_labels_additional_labels: ''


### PR DESCRIPTION
Changed container repository from paperless-ngx/tika to apache/tika, because paperless-ngx/tika has been archived. See: https://github.com/paperless-ngx/tika