### PR TITLE
chore: update to latest version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@
 paperless_enabled: true
 paperless_identifier: paperless
 
-paperless_version: "2.12.1"
+paperless_version: "2.13.0"
 # In mb, default is 10gb
 paperless_tmp_size: 10000
 
@@ -232,7 +232,7 @@ paperless_tika_identifier: "{{ paperless_identifier }}-tika"
 paperless_tika_endpoint: "http://{{ paperless_tika_identifier }}:9998"
 paperless_tika_container_additional_mounts: []
 paperless_tika_container_registry_prefix: "docker.io/"
-paperless_tika_version: "2.9.2.1"
+paperless_tika_version: "3.0.0.0"
 paperless_tika_container_image: "{{ paperless_tika_container_registry_prefix }}apache/tika:{{ paperless_tika_version }}"
 paperless_tika_environment_variables_extension: ''
 paperless_tika_container_labels_additional_labels: ''
@@ -243,7 +243,7 @@ paperless_gotenberg_identifier: "{{ paperless_identifier }}-gotenberg"
 paperless_gotenberg_endpoint: "http://{{ paperless_gotenberg_identifier }}:3000"
 paperless_gotenberg_container_additional_mounts: []
 paperless_gotenberg_container_registry_prefix: "docker.io/"
-paperless_gotenberg_version: "8.10.0"
+paperless_gotenberg_version: "8.12.0"
 paperless_gotenberg_container_image: "{{ paperless_gotenberg_container_registry_prefix }}gotenberg/gotenberg:{{ paperless_gotenberg_version }}"
 paperless_gotenberg_environment_variables_extension: ''
 paperless_gotenberg_container_labels_additional_labels: ''


### PR DESCRIPTION
paperless-ngx: 2.13.0
tika: 3.0.0.0
gotenberg: 8.12.0