### PR TITLE
fix: support s6, which is used since 2.15.0

### DIFF
--- a/templates/env.j2
+++ b/templates/env.j2
@@ -44,4 +44,7 @@ PAPERLESS_TIKA_ENDPOINT={{ paperless_tika_endpoint }}
 PAPERLESS_TIKA_GOTENBERG_ENDPOINT={{ paperless_gotenberg_endpoint }}
 {% endif %}
 
+# set read-only filesystem for S6
+S6_READ_ONLY_ROOT=1
+
 {{ paperless_environment_variables_extension }}

--- a/templates/systemd/paperless.service.j2
+++ b/templates/systemd/paperless.service.j2
@@ -33,6 +33,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--tmpfs=/tmp:rw,noexec,nosuid,size={{ paperless_tmp_size }}m \
 			--tmpfs=/var/log/supervisord:rw,noexec,nosuid,size=20m \
 			--tmpfs=/var/run/supervisord:rw,noexec,nosuid,size=10m \
+			--tmpfs=/run:rw,exec,nosuid,size=10m \
 			{{ paperless_container_image }}
 
 {% for network in paperless_container_additional_networks %}


### PR DESCRIPTION
With this commit it should be okay to switch back the mash-playbook to v2.15.2.